### PR TITLE
Pod fixes

### DIFF
--- a/lib/PPIx/EditorTools/FindUnmatchedBrace.pm
+++ b/lib/PPIx/EditorTools/FindUnmatchedBrace.pm
@@ -40,6 +40,7 @@ Finds the location of unmatched braces in a C<PPI::Document>.
 Constructor. Generally shouldn't be called with any arguments.
 
 =item find( ppi => PPI::Document $ppi )
+
 =item find( code => Str $code )
 
 Accepts either a C<PPI::Document> to process or a string containing

--- a/lib/PPIx/EditorTools/FindVariableDeclaration.pm
+++ b/lib/PPIx/EditorTools/FindVariableDeclaration.pm
@@ -24,7 +24,7 @@ PPIx::EditorTools::FindVariableDeclaration - inds where a variable was declared 
   my $declaration = PPIx::EditorTools::FindVariableDeclaration->new->find(
     code =>
       "package TestPackage;\nuse strict;\nBEGIN {
-	$^W = 1;
+    \$^W = 1;
 }\nmy \$x=1;\n\$x++;"
     line => 5,
     column => 2,
@@ -44,6 +44,7 @@ Finds the location of a variable declaration.
 Constructor. Generally shouldn't be called with any arguments.
 
 =item find( ppi => PPI::Document $ppi, line => $line, column => $column )
+
 =item find( code => Str $code, line => $line, column => $column )
 
 Accepts either a C<PPI::Document> to process or a string containing

--- a/lib/PPIx/EditorTools/IntroduceTemporaryVariable.pm
+++ b/lib/PPIx/EditorTools/IntroduceTemporaryVariable.pm
@@ -52,6 +52,7 @@ selected expression.
 Constructor. Generally shouldn't be called with any arguments.
 
 =item find( ppi => PPI::Document, start_location => Int, end_location => Int, varname => Str )
+
 =item find( code => Str, start_location => Int, end_location => Int, varname => Str )
 
 Accepts either a C<PPI::Document> to process or a string containing

--- a/lib/PPIx/EditorTools/Lexer.pm
+++ b/lib/PPIx/EditorTools/Lexer.pm
@@ -51,6 +51,7 @@ the follow values:
 Constructor. Generally shouldn't be called with any arguments.
 
 =item find( ppi => PPI::Document $ppi, highlighter => sub {...} )
+
 =item find( code => Str $code, highlighter => sub ...{} )
 
 Accepts either a C<PPI::Document> to process or a string containing

--- a/lib/PPIx/EditorTools/RenamePackage.pm
+++ b/lib/PPIx/EditorTools/RenamePackage.pm
@@ -25,9 +25,13 @@ PPIx::EditorTools::RenamePackage - Change the package name
 =head1 SYNOPSIS
 
     my $munged = PPIx::EditorTools::RenamePackage->new->rename(
-        code        => "package TestPackage;\nuse strict;\nBEGIN {
-	$^W = 1;
-}\n1;\n",
+        code        => <<'END_CODE',
+            package TestPackage;
+            use strict;
+
+            BEGIN { $^W = 1; }
+            1;
+    END_CODE
         replacement => 'NewPackage'
     );
 

--- a/lib/PPIx/EditorTools/RenamePackage.pm
+++ b/lib/PPIx/EditorTools/RenamePackage.pm
@@ -51,6 +51,7 @@ This module uses PPI to change the package name of code.
 Constructor. Generally shouldn't be called with any arguments.
 
 =item rename( ppi => PPI::Document $ppi, replacement => Str )
+
 =item rename( code => Str $code, replacement => Str )
 
 Accepts either a C<PPI::Document> to process or a string containing

--- a/lib/PPIx/EditorTools/RenamePackageFromPath.pm
+++ b/lib/PPIx/EditorTools/RenamePackageFromPath.pm
@@ -51,6 +51,7 @@ This module uses PPI to change the package name of code.
 Constructor. Generally shouldn't be called with any arguments.
 
 =item rename( ppi => PPI::Document $ppi, filename => Str )
+
 =item rename( code => Str $code, filename => Str )
 
 Accepts either a C<PPI::Document> to process or a string containing

--- a/lib/PPIx/EditorTools/RenameVariable.pm
+++ b/lib/PPIx/EditorTools/RenameVariable.pm
@@ -43,8 +43,11 @@ This module will lexically replace a variable name.
 Constructor. Generally shouldn't be called with any arguments.
 
 =item rename( ppi => PPI::Document $ppi, line => Int, column => Int, replacement => Str )
+
 =item rename( code => Str $code, line => Int, column => Int, replacement => Str )
+
 =item rename( code => Str $code, line => Int, column => Int, to_camel_case => Bool, [ucfirst => Bool] )
+
 =item rename( code => Str $code, line => Int, column => Int, from_camel_case => Bool, [ucfirst => Bool] )
 
 Accepts either a C<PPI::Document> to process or a string containing


### PR DESCRIPTION
A few POD-related fixes. Mostly interspacing the `=item`s with line feeds, as they are taken as a single `=item` otherwise.